### PR TITLE
Update supplypacks.dm

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -2505,12 +2505,12 @@ FACTORY
 /datum/supply_packs/factory/heavy_isg_he_refill
 	name = "FK-88 Flak HE shell assembly refill"
 	contains = list(/obj/item/factory_refill/heavy_isg_he_refill)
-	cost = 300
+	cost = 200 // makes it 40 points a shell
 
 /datum/supply_packs/factory/heavy_isg_sabot_refill
 	name = "FK-88 Flak APFDS shell assembly refill"
 	contains = list(/obj/item/factory_refill/heavy_isg_sabot_refill)
-	cost = 400
+	cost = 225 // makes it 45 points a shell
 
 /datum/supply_packs/factory/ac_hv_refill
 	name = "ATR-22 High Velocity magazine assembly refill"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes prices for the FK-88 Shell refills for factory to bring it actually cheaper than just buying rounds directly, to actually make it make sense to factory. HE shells are 40 Points/shell when Factory-ing now (Instead of 60 Points/shell as prior) and APFDS shells are now 45 Points/shell when Factory-ing (Instead of the 80! Points/shell prior)

## Why It's Good For The Game

Right now it logically makes no sense to ever setup a FK-88 shell factory as its less economically to process the refill packs than just buying shells directly from the terminal, this change hopefully fixes that issue and brings the price in-line with a slight discount over the default shell prices of 50/shell in Weapons section

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Price Adjustment of FK-88 HE and APFDS refills for the factory to bring them slightly cheaper than outright buying shells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
